### PR TITLE
Normalize user data before validation

### DIFF
--- a/parrot-api/model/user.go
+++ b/parrot-api/model/user.go
@@ -32,8 +32,15 @@ type User struct {
 	Password string `db:"password" json:"password,omitempty"`
 }
 
+func (u *User) Normalize() {
+	u.Email = strings.ToLower(u.Email)
+}
+
 // Validate returns an error if the user's data is invalid.
+// It will normalize the user data before validating
 func (u *User) Validate() error {
+	u.Normalize()
+
 	var errs []errors.Error
 	if !ValidEmail(u.Email) {
 		errs = append(errs, *ErrInvalidEmail)


### PR DESCRIPTION
This closes #46 

Should work with existing data sets as no records were allowed to contain uppercase characters. From now on, all uppercase characters will be accepted as input but will be normalized after parsing.